### PR TITLE
Add lost Transform type to public objects of types module

### DIFF
--- a/lollipop/types.py
+++ b/lollipop/types.py
@@ -28,6 +28,7 @@ __all__ = [
     'Optional',
     'LoadOnly',
     'DumpOnly',
+    'Transform',
     'validated_type',
 ]
 


### PR DESCRIPTION
So, Transform type is not passed in docs build, because of `automodule` can not import it.