### PR TITLE
Fix List type accepting strings

### DIFF
--- a/lollipop/types.py
+++ b/lollipop/types.py
@@ -376,8 +376,7 @@ class List(Type):
         if data is MISSING or data is None:
             self._fail('required')
 
-        # TODO: Make more intelligent check for collections
-        if not is_sequence(data):
+        if not is_sequence(data) or isinstance(data, string_types):
             self._fail('invalid')
 
         errors_builder = ValidationErrorBuilder()
@@ -395,7 +394,7 @@ class List(Type):
         if value is MISSING or value is None:
             self._fail('required')
 
-        if not is_sequence(value):
+        if not is_sequence(value) or isinstance(value, string_types):
             self._fail('invalid')
 
         errors_builder = ValidationErrorBuilder()

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -512,6 +512,11 @@ class TestList(NameDescriptionTestsMixin, RequiredTestsMixin, ValidationTestsMix
             List(String()).load(123)
         assert exc_info.value.messages == List.default_error_messages['invalid']
 
+    def test_loading_string_value_raises_ValidationError(self):
+        with pytest.raises(ValidationError) as exc_info:
+            List(String()).load('foo')
+        assert exc_info.value.messages == List.default_error_messages['invalid']
+
     def test_loading_list_value_with_items_of_incorrect_type_raises_ValidationError(self):
         with pytest.raises(ValidationError) as exc_info:
             List(String()).load([1, '2', 3])
@@ -544,11 +549,15 @@ class TestList(NameDescriptionTestsMixin, RequiredTestsMixin, ValidationTestsMix
 
     def test_dumping_sequence_value(self):
         assert List(String()).dump(('foo', 'bar', 'baz')) == ['foo', 'bar', 'baz']
-        assert List(String()).dump('foobar') == ['f', 'o', 'o', 'b', 'a', 'r']
 
     def test_dumping_non_list_value_raises_ValidationError(self):
         with pytest.raises(ValidationError) as exc_info:
             List(String()).dump(123)
+        assert exc_info.value.messages == List.default_error_messages['invalid']
+
+    def test_dumping_string_value_raises_ValidationError(self):
+        with pytest.raises(ValidationError) as exc_info:
+            List(String()).dump('foo')
         assert exc_info.value.messages == List.default_error_messages['invalid']
 
     def test_dumping_list_value_with_items_of_incorrect_type_raises_ValidationError(self):


### PR DESCRIPTION
Currently if you pass a string value in place of list,
it will validate OK, because strings in Python are also
sequences (of individual char strings). From validation
point of view it is incorrect.

This patch adds extra check to List type do check that
values are not strings (but you still can use custom
sequence types).