### PR TITLE
Support PEP3102 and PEP570

### DIFF
--- a/lollipop/utils.py
+++ b/lollipop/utils.py
@@ -1,6 +1,6 @@
 import inspect
 import re
-from lollipop.compat import DictMixin, iterkeys
+from lollipop.compat import DictMixin, iterkeys, PY2
 import collections
 
 
@@ -23,6 +23,16 @@ def is_mapping(value):
     """Returns True if value supports dict interface; False - otherwise"""
     return isinstance(value, collections.Mapping)
 
+def get_arg_count(func):
+    """Calculates a number of arguments based on a signature."""
+
+    if PY2:
+        return len(inspect.getargspec(func).args)
+
+    spec = inspect.getfullargspec(func)
+
+    return len(spec.args) + len(spec.kwonlyargs)
+
 
 # Backward compatibility
 is_list = is_sequence
@@ -37,13 +47,13 @@ def make_context_aware(func, numargs):
     """
     try:
         if inspect.ismethod(func):
-            arg_count = len(inspect.getargspec(func).args) - 1
+            arg_count = get_arg_count(func) - 1
         elif inspect.isfunction(func):
-            arg_count = len(inspect.getargspec(func).args)
+            arg_count = get_arg_count(func)
         elif inspect.isclass(func):
-            arg_count = len(inspect.getargspec(func.__init__).args) - 1
+            arg_count = get_arg_count(func.__init__) - 1
         else:
-            arg_count = len(inspect.getargspec(func.__call__).args) - 1
+            arg_count = get_arg_count(func.__call__) - 1
     except TypeError:
         arg_count = numargs
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import sys
 from lollipop.compat import iterkeys, itervalues, iteritems
 from lollipop.utils import call_with_context, to_camel_case, to_snake_case, \
     constant, identity, OpenStruct, DictWithDefault
@@ -28,6 +29,19 @@ class ObjClassDummy:
 
 
 class TestCallWithContext:
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason='Requires python 3.8+')
+    def test_calls_complex_signature(self):
+        class NonLocal:
+            args = None
+
+        def func(a, b, /, c, *d, e=1, f=2, **g):
+            NonLocal.args = a, b, c, d, e, f, g
+            return 42
+
+        context = object()
+        assert call_with_context(func, context, 1, 'foo', True) == 42
+        assert NonLocal.args == (1, 'foo', True, (context,), 1, 2, {})
+
     def test_calls_function_with_given_arguments(self):
         class NonLocal:
             args = None


### PR DESCRIPTION
PEP3102 and PEP570 amend Python grammar and allow to support positional and keyword only parameters.

For example:

    def func(a, b, /, c, d, *, e=1, f=2):
        pass

This function allows `a`, `b` to be positional only so you can't call `func(a=1...` anymore. It also require `e` and `f` to be a keyword parameters only so you can't have a positional argument that would be matched.

This commit correctly calculates a number of the given arguments based on that rule. Also, since Python 3.11 deprecated `inspect.getargspec`, it also uses other function.