### PR TITLE
Use correct import paths for Mapping and Sequence

### DIFF
--- a/lollipop/compat.py
+++ b/lollipop/compat.py
@@ -26,6 +26,12 @@ if PY26:
 else:
     from collections import OrderedDict
     try:
-        from collections import MutableMapping as DictMixin
+        from collections import (
+            MutableMapping as DictMixin,
+            Mapping,
+            Sequence)
     except ImportError:
-        from collections.abc import MutableMapping as DictMixin
+        from collections.abc import (
+            MutableMapping as DictMixin,
+            Mapping,
+            Sequence)

--- a/lollipop/utils.py
+++ b/lollipop/utils.py
@@ -1,7 +1,6 @@
 import inspect
 import re
-from lollipop.compat import DictMixin, iterkeys
-import collections
+from lollipop.compat import DictMixin, Sequence, Mapping, iterkeys
 
 
 def identity(value):
@@ -17,11 +16,11 @@ def constant(value):
 
 def is_sequence(value):
     """Returns True if value supports list interface; False - otherwise"""
-    return isinstance(value, collections.Sequence)
+    return isinstance(value, Sequence)
 
 def is_mapping(value):
     """Returns True if value supports dict interface; False - otherwise"""
-    return isinstance(value, collections.Mapping)
+    return isinstance(value, Mapping)
 
 
 # Backward compatibility


### PR DESCRIPTION
This commit enriches compat module to import `Mapping` and `Sequence` from `collections.abc` instead of `collections`. This deprecation is to support Python3.9+